### PR TITLE
chore: remove unused property axisColors

### DIFF
--- a/src/chart/chart.config.ts
+++ b/src/chart/chart.config.ts
@@ -358,7 +358,6 @@ export const getDefaultConfig = (): FullChartConfig => ({
 			backgroundColor: 'rgba(20,20,19,1)',
 			backgroundGradientTopColor: 'red',
 			backgroundGradientBottomColor: 'blue',
-			axisColor: 'rgba(128,128,128,1)',
 			gridColor: 'rgba(37,37,36,1)',
 		},
 		scatterPlot: { mainColor: 'rgba(255,255,255,1)' },
@@ -1383,7 +1382,6 @@ export interface ChartAreaTheme {
 	backgroundColor: string;
 	backgroundGradientTopColor: string;
 	backgroundGradientBottomColor: string;
-	axisColor: string;
 	gridColor: string;
 }
 


### PR DESCRIPTION
Let's remove it, since for axis colors we use separate properties `config.colors.xAxis.backgroundColor` and `config.colors.yAxis.backgroundColor`