### PR TITLE
chore: remove useless flag and fix typos

### DIFF
--- a/src/chart/model/scale.model.ts
+++ b/src/chart/model/scale.model.ts
@@ -85,7 +85,7 @@ export class ScaleModel extends ViewportModel {
 
 	/**
 	 * The method adds a new "constraint" to the existing list of x-axis constraints for charting.
-	 * The "constrait" is expected to be an object containing information about the constraints, such as the minimum and maximum values for the x-axis.
+	 * The "constraint" is expected to be an object containing information about the constraints, such as the minimum and maximum values for the x-axis.
 	 * @param constraint
 	 */
 	addXConstraint(constraint: Constraints) {
@@ -158,7 +158,7 @@ export class ScaleModel extends ViewportModel {
 			lockedYEndViewportCalculator(constrainedState, this.zoomXYRatio);
 		}
 		if (this.state.auto) {
-			this.autoScaleModel.setAutoAndRecalculateState(constrainedState, true);
+			this.autoScaleModel.doAutoYScale(constrainedState);
 		}
 
 		if (forceNoAnimation) {
@@ -180,15 +180,15 @@ export class ScaleModel extends ViewportModel {
 		const initialState = this.export();
 		super.setXScale(xStart, xEnd, false);
 		const state = this.export();
-		const constraitedState = this.scalePostProcessor(initialState, state);
+		const constrainedState = this.scalePostProcessor(initialState, state);
 		if (this.state.lockPriceToBarRatio) {
-			lockedYEndViewportCalculator(constraitedState, this.zoomXYRatio);
+			lockedYEndViewportCalculator(constrainedState, this.zoomXYRatio);
 		}
 		if (this.state.auto) {
-			this.autoScaleModel.setAutoAndRecalculateState(constraitedState, true);
+			this.autoScaleModel.doAutoYScale(constrainedState);
 		}
 
-		this.apply(constraitedState);
+		this.apply(constrainedState);
 	}
 
 	/**
@@ -202,12 +202,12 @@ export class ScaleModel extends ViewportModel {
 		// always stop the animations
 		this.haltAnimation();
 		moveXStart(state, xStart);
-		// there we need only candles constrait
-		const constraitedState = this.scalePostProcessor(initialStateCopy, state);
+		// there we need only candles constraint
+		const constrainedState = this.scalePostProcessor(initialStateCopy, state);
 		if (this.state.auto) {
-			this.autoScaleModel.setAutoAndRecalculateState(constraitedState, true);
+			this.autoScaleModel.doAutoYScale(constrainedState);
 		}
-		this.apply(constraitedState);
+		this.apply(constrainedState);
 	}
 
 	private scalePostProcessor = (initialState: ViewportModelState, state: ViewportModelState) => {
@@ -240,7 +240,7 @@ export class ScaleModel extends ViewportModel {
 		// dont auto-scale if animation, otherwise - forced or config
 		if ((!this.isViewportAnimationInProgress() && this.state.auto) || forceApply) {
 			const state = this.export();
-			this.autoScaleModel.setAutoAndRecalculateState(state, true);
+			this.autoScaleModel.doAutoYScale(state);
 			if (!compareStates(state, this.export())) {
 				this.apply(state);
 			}

--- a/src/chart/model/scaling/auto-scale.model.ts
+++ b/src/chart/model/scaling/auto-scale.model.ts
@@ -32,12 +32,10 @@ type HighLowPostProcessor = (highLow: HighLow) => HighLow;
  * @doc-tags auto-scale,viewport,scaling
  */
 export class AutoScaleViewportSubModel {
-	// local state, used for pane X dragging
-	auto: boolean = true;
 	// providers of high-low extrems for viewport calculation
 	highLowProviders: Record<string, HighLowProvider>;
 	// post processors can apply some changes to high low before applying it
-	highLowPostPorcessor: Record<string, HighLowPostProcessor> = {};
+	highLowPostProcessor: Record<string, HighLowPostProcessor> = {};
 
 	constructor(private delegate: ViewportModel, highLowProviders?: Record<string, HighLowProvider>) {
 		this.highLowProviders = highLowProviders ?? {};
@@ -68,25 +66,21 @@ export class AutoScaleViewportSubModel {
 	 * @returns {void}
 	 */
 	setHighLowPostProcessor(name: string, processor: HighLowPostProcessor) {
-		this.highLowPostPorcessor[name] = processor;
+		this.highLowPostProcessor[name] = processor;
 	}
 
 	/**
 	 * Sets the auto and recalculates the state of the viewport model.
 	 * @param {ViewportModelState} state - The state of the viewport model.
-	 * @param {boolean} auto - The auto value to set.
 	 * @returns {void}
 	 */
-	setAutoAndRecalculateState(state: ViewportModelState, auto: boolean) {
-		this.auto = auto;
-		if (auto) {
-			autoScaleYViewportTransformer(
-				this.delegate,
-				state,
-				Object.values(this.highLowProviders),
-				Object.values(this.highLowPostPorcessor),
-			);
-		}
+	doAutoYScale(state: ViewportModelState) {
+		autoScaleYViewportTransformer(
+			this.delegate,
+			state,
+			Object.values(this.highLowProviders),
+			Object.values(this.highLowPostProcessor),
+		);
 	}
 }
 


### PR DESCRIPTION
`chart.scale.autoScaleModel.auto` in fact was unused, so I've removed it