### PR TITLE
fix: errors in XAxisTimeLabelsGenerator after prepending candles

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,8 @@ module.exports = {
 	transform: {
 		'\\.[jt]sx?$': 'esbuild-jest',
 	},
+	moduleNameMapper: {
+		'date-fns/esm': 'date-fns',
+	},
+	setupFiles: ['jest-canvas-mock'],
 };

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "husky": "^8.0.2",
     "is-glob": "^4.0.3",
     "jest": "^24.9.0",
+    "jest-canvas-mock": "^2.5.2",
     "lint-staged": "^13.0.4",
     "mocha": "9.2.0",
     "node-html-parser": "^6.1.5",

--- a/src/chart/__tests__/chart.test.ts
+++ b/src/chart/__tests__/chart.test.ts
@@ -10,11 +10,13 @@ describe('chart', () => {
 		['prepend candles', [candles.slice(10), candles.slice(0, 10)]],
 		['prepend with a gap', [candles.slice(0, 10), candles.slice(20, 30)]],
 		['prepend with overlap', [candles.slice(10), candles.slice(0, 20)]],
+		['prepend with full overlap', [candles.slice(10), candles]],
 		['only update existing candles', [candles, candles.slice(10, 20)]],
 		['update all candles', [candles, candles]],
 		['append candles', [candles.slice(0, 10), candles.slice(10)]],
 		['append candles with a gap', [candles.slice(0, 10), candles.slice(20)]],
 		['append candles with overlap', [candles.slice(0, 20), candles.slice(10)]],
+		['append candles with full overlap', [candles.slice(0, 20), candles]],
 		['prepend and append', [candles.slice(10, 20), candles.slice(0, 30)]],
 		[
 			"fill in the gap (won't work but should not error)",

--- a/src/chart/__tests__/chart.test.ts
+++ b/src/chart/__tests__/chart.test.ts
@@ -1,0 +1,36 @@
+import './env';
+import { createChart } from '../../index';
+import { generateCandlesDataTS } from '../utils/candles-generator-ts.utils';
+
+describe('chart', () => {
+	const candles = generateCandlesDataTS({ quantity: 50 });
+
+	it.each([
+		['zero -> non-zero candles', [[], candles]],
+		['prepend candles', [candles.slice(10), candles.slice(0, 10)]],
+		['prepend with a gap', [candles.slice(0, 10), candles.slice(20, 30)]],
+		['prepend with overlap', [candles.slice(10), candles.slice(0, 20)]],
+		['only update existing candles', [candles, candles.slice(10, 20)]],
+		['update all candles', [candles, candles]],
+		['append candles', [candles.slice(0, 10), candles.slice(10)]],
+		['append candles with a gap', [candles.slice(0, 10), candles.slice(20)]],
+		['append candles with overlap', [candles.slice(0, 20), candles.slice(10)]],
+		['prepend and append', [candles.slice(10, 20), candles.slice(0, 30)]],
+		[
+			"fill in the gap (won't work but should not error)",
+			[candles.slice(0, 10), candles.slice(11, 20), candles.slice(10, 11)],
+		],
+	])('should update candles in various scenarios: %s', async (scenario, updates) => {
+		const div = document.createElement('div');
+		const chart = createChart(div);
+		updates.forEach((update, i) => {
+			if (i === 0) {
+				chart.setData({ candles: update });
+			} else {
+				chart.updateData({ candles: update });
+			}
+		});
+		// wait for async tasks to complete successfully
+		await new Promise(done => setTimeout(done, 100));
+	});
+});

--- a/src/chart/__tests__/env.ts
+++ b/src/chart/__tests__/env.ts
@@ -1,0 +1,25 @@
+/* @see https://jestjs.io/docs/29.4/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom */
+Object.defineProperty(window, 'matchMedia', {
+	writable: true,
+	value: jest.fn().mockImplementation(query => ({
+		matches: false,
+		media: query,
+		onchange: null,
+		addListener: jest.fn(), // deprecated
+		removeListener: jest.fn(), // deprecated
+		addEventListener: jest.fn(),
+		removeEventListener: jest.fn(),
+		dispatchEvent: jest.fn(),
+	})),
+});
+
+Object.defineProperty(window, 'ResizeObserver', {
+	writable: true,
+	value: jest.fn().mockImplementation(
+		(): ResizeObserver => ({
+			observe: jest.fn(),
+			unobserve: jest.fn(),
+			disconnect: jest.fn(),
+		}),
+	),
+});

--- a/src/chart/components/chart/chart-base.model.ts
+++ b/src/chart/components/chart/chart-base.model.ts
@@ -18,6 +18,7 @@ type DataPoint<T extends BaseType> = T extends 'candle' ? Candle : DataSeriesPoi
 type VisualPoint<T extends BaseType> = T extends 'candle' ? VisualCandle : VisualSeriesPoint;
 export interface PrependedCandlesData {
 	prependedCandlesWidth: number;
+	prependedCandlesCount: number;
 	preparedCandles: Candle[];
 }
 

--- a/src/chart/components/chart/chart-base.model.ts
+++ b/src/chart/components/chart/chart-base.model.ts
@@ -18,8 +18,7 @@ type DataPoint<T extends BaseType> = T extends 'candle' ? Candle : DataSeriesPoi
 type VisualPoint<T extends BaseType> = T extends 'candle' ? VisualCandle : VisualSeriesPoint;
 export interface PrependedCandlesData {
 	prependedCandlesWidth: number;
-	prependedCandlesCount: number;
-	preparedCandles: Candle[];
+	prependedCandles: Candle[];
 }
 
 /**

--- a/src/chart/components/chart/chart.model.ts
+++ b/src/chart/components/chart/chart.model.ts
@@ -389,6 +389,7 @@ export class ChartModel extends ChartBaseElement {
 		this.scale.moveXStart(this.scale.xStart + prependedCandlesWidth);
 		this.candlesPrependSubject.next({
 			prependedCandlesWidth,
+			prependedCandlesCount: updateResult.prepended,
 			preparedCandles,
 		});
 

--- a/src/chart/components/chart/chart.model.ts
+++ b/src/chart/components/chart/chart.model.ts
@@ -384,13 +384,12 @@ export class ChartModel extends ChartBaseElement {
 
 		// caclulate offset width for prepanded candles
 		const prependedCandlesWidth = this.chartBaseModel.mainVisualPoints
-			.slice(0, updateResult.prepended)
+			.slice(0, updateResult.prepended.length)
 			.reduce((acc, cur) => acc + cur.width, 0);
 		this.scale.moveXStart(this.scale.xStart + prependedCandlesWidth);
 		this.candlesPrependSubject.next({
 			prependedCandlesWidth,
-			prependedCandlesCount: updateResult.prepended,
-			preparedCandles,
+			prependedCandles: updateResult.prepended,
 		});
 
 		this.chartBaseModel.recalculatePeriod();
@@ -1065,7 +1064,7 @@ export class ChartModel extends ChartBaseElement {
 		});
 
 		return {
-			prepended: prepend.length,
+			prepended: prepend,
 			candles: [...prepend, ...targetCopy],
 		};
 	}
@@ -1111,8 +1110,8 @@ export class ChartModel extends ChartBaseElement {
 }
 
 export interface UpdateCandlesResult {
-	prepended: number;
-	appended?: number;
+	prepended: Candle[];
+	appended?: Candle[];
 	candles: Candle[];
 }
 
@@ -1161,8 +1160,8 @@ const updateCandles = (target: Candle[], update: Candle[]): UpdateCandlesResult 
 	});
 
 	return {
-		prepended: prepend.length,
-		appended: append.length,
+		prepended: prepend,
+		appended: append,
 		candles: [...prepend, ...targetCopy, ...append],
 	};
 };

--- a/src/chart/components/x_axis/x-axis.component.ts
+++ b/src/chart/components/x_axis/x-axis.component.ts
@@ -120,11 +120,11 @@ export class XAxisComponent extends ChartBaseElement {
 		this.addRxSubscription(
 			this.chartComponent.chartModel.candlesPrependSubject
 				.pipe(
-					filter(({ preparedCandles }) => preparedCandles.length !== 0),
-					map(({ preparedCandles }) => {
+					filter(({ prependedCandlesCount }) => prependedCandlesCount !== 0),
+					map(({ prependedCandlesCount }) => {
 						return this.chartComponent.chartModel.mainCandleSeries.visualPoints.slice(
 							0,
-							preparedCandles.length,
+							prependedCandlesCount,
 						);
 					}),
 				)

--- a/src/chart/components/x_axis/x-axis.component.ts
+++ b/src/chart/components/x_axis/x-axis.component.ts
@@ -120,11 +120,11 @@ export class XAxisComponent extends ChartBaseElement {
 		this.addRxSubscription(
 			this.chartComponent.chartModel.candlesPrependSubject
 				.pipe(
-					filter(({ prependedCandlesCount }) => prependedCandlesCount !== 0),
-					map(({ prependedCandlesCount }) => {
+					filter(({ prependedCandles }) => prependedCandles.length !== 0),
+					map(({ prependedCandles }) => {
 						return this.chartComponent.chartModel.mainCandleSeries.visualPoints.slice(
 							0,
-							prependedCandlesCount,
+							prependedCandles.length,
 						);
 					}),
 				)

--- a/yarn.lock
+++ b/yarn.lock
@@ -663,6 +663,7 @@ __metadata:
     husky: ^8.0.2
     is-glob: ^4.0.3
     jest: ^24.9.0
+    jest-canvas-mock: ^2.5.2
     lint-staged: ^13.0.4
     mocha: 9.2.0
     node-html-parser: ^6.1.5
@@ -3397,7 +3398,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
+"color-name@npm:^1.0.0, color-name@npm:^1.1.4, color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
@@ -3682,6 +3683,13 @@ __metadata:
   version: 6.1.0
   resolution: "css-what@npm:6.1.0"
   checksum: b975e547e1e90b79625918f84e67db5d33d896e6de846c9b584094e529f0c63e2ab85ee33b9daffd05bff3a146a1916bec664e18bb76dd5f66cbff9fc13b2bbe
+  languageName: node
+  linkType: hard
+
+"cssfontparser@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "cssfontparser@npm:1.2.1"
+  checksum: 952d487cddab591fb944f2a4c326a7736bc963784a6d92b6ad4051f3bf5ee49a732eff62e29a52ff085197cb07f5bd66525a2245ded7fd356113ac81be9238b9
   languageName: node
   linkType: hard
 
@@ -6572,6 +6580,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-canvas-mock@npm:^2.5.2":
+  version: 2.5.2
+  resolution: "jest-canvas-mock@npm:2.5.2"
+  dependencies:
+    cssfontparser: ^1.2.1
+    moo-color: ^1.0.2
+  checksum: a3004d2e96473049045e49dcf98e5ea6011494048ab42b5422b3089d9ff406aaca8353e79587055d840fa145541668eb8f78613765f252ad5901a8217e91ea5d
+  languageName: node
+  linkType: hard
+
 "jest-changed-files@npm:^24.9.0":
   version: 24.9.0
   resolution: "jest-changed-files@npm:24.9.0"
@@ -7979,6 +7997,15 @@ __metadata:
     _mocha: bin/_mocha
     mocha: bin/mocha
   checksum: 49efc4724cf17087c7e107bc8f6890db24525e6dcc153b801da58de3c2a2f940e22f7600ef195b8ac62a0dfd7baee5cf289fc4641a6b1fdf8bc9c819efc1a8ba
+  languageName: node
+  linkType: hard
+
+"moo-color@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "moo-color@npm:1.0.3"
+  dependencies:
+    color-name: ^1.1.4
+  checksum: 02bf59b6bbd5e86641bc062e2dc0843e6e579e18ef67e1c8e93bfc01945df578f20e66ce16aa9632db2aa0e16806e0914a26eb345a804f45fff1ae12a8906a29
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Hi team,

We have encountered an issue with `Chart.updateData` in several cases. The most "production-like" failing scenario is where the chart starts with an empty array of candles, and more candles are added later.

Some reproduction scenarios: https://codepen.io/dmkokovtsev/pen/rNoZJwG

Stacktraces:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'candle')
    at mapCandlesToWeightedPoints (x-axis-weights.generator.js:42:1)
    at XAxisTimeLabelsGenerator.updateHistoryLabels (x-axis-labels.generator.js:170:1)
    at Object.eval [as next] (x-axis.component.js:66:1)
    at ConsumerObserver.next (Subscriber.js:96:1)
    at Subscriber._next (Subscriber.js:63:1)
    at Subscriber.next (Subscriber.js:34:1)
    at eval (map.js:7:1)
    at OperatorSubscriber._this._next (OperatorSubscriber.js:15:1)
    at Subscriber.next (Subscriber.js:34:1)
    at eval (filter.js:6:1)
```
```
Uncaught TypeError: Cannot read properties of undefined (reading 'shift')
    at eval (x-axis-labels.generator.js:188:1)
    at Array.reduce (<anonymous>)
    at XAxisTimeLabelsGenerator.updateHistoryLabels (x-axis-labels.generator.js:182:1)
    at Object.eval [as next] (x-axis.component.js:66:1)
    at ConsumerObserver.next (Subscriber.js:96:1)
    at Subscriber._next (Subscriber.js:63:1)
    at Subscriber.next (Subscriber.js:34:1)
    at eval (map.js:7:1)
    at OperatorSubscriber._this._next (OperatorSubscriber.js:15:1)
    at Subscriber.next (Subscriber.js:34:1)
```