### PR TITLE
fix: optimize getBounds method

### DIFF
--- a/src/chart/model/baseline.model.ts
+++ b/src/chart/model/baseline.model.ts
@@ -102,7 +102,7 @@ export class BaselineModel extends ChartBaseElement {
 		this.resizerBounds.height = this.config.components.baseline.height;
 		const relativeBaselineY = chart.y + chart.height * (this.baselineYPercents / 100);
 		this.resizerBounds.y = relativeBaselineY;
-		this.canvasBoundContainer.bounds[BASELINE_RESIZER_UUID] = this.resizerBounds;
+		this.canvasBoundContainer.bounds.set(BASELINE_RESIZER_UUID, this.resizerBounds);
 	}
 
 	/**


### PR DESCRIPTION
These measurements were done during dragging chart on time window of 1.5 seconds

before:
![image](https://github.com/devexperts/dxcharts-lite/assets/44753430/5ee694f0-33fa-4796-89ac-7dc8d9a041f7)
after:
![image](https://github.com/devexperts/dxcharts-lite/assets/44753430/3f81be63-7e9f-4448-9639-ee220d4948c7)
