### PR TITLE
fix: optimize getBounds method

### DIFF
--- a/src/chart/canvas/canvas-bounds-container.ts
+++ b/src/chart/canvas/canvas-bounds-container.ts
@@ -660,10 +660,12 @@ export class CanvasBoundsContainer {
 	 * @return {Bounds} bounds of element
 	 */
 	public getBounds(el: string): Bounds {
-		if (this.bounds[el] === undefined) {
-			this.bounds[el] = this.copyOf(DEFAULT_BOUNDS);
+		let bounds = this.bounds[el];
+		if (bounds === undefined) {
+			bounds = this.copyOf(DEFAULT_BOUNDS);
+			this.bounds[el] = bounds;
 		}
-		return this.bounds[el];
+		return bounds;
 	}
 	/**
 	 * Returns the position of CANVAS on whole page.


### PR DESCRIPTION
Seems like Object access is still faster than Map in Chrome.
On 4000 ms window I got the following results:

- without optimizations: `getBounds()` time - 200ms

- with map & optimized access: `getBounds()` time - 120ms 

- with object & optimized access: `getBounds()` time - 80ms 