### PR TITLE
Manual bump version after v2.3.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devexperts/dxcharts-lite",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "DXCharts Lite",
   "author": "Devexperts Solutions IE Limited",
   "license": "MPL 2.0",


### PR DESCRIPTION
Currently, release script is not perfect, so version change wasn't commited to repo at the time of release.