### PR TITLE
fix: doji candles are shown as dots

### DIFF
--- a/src/chart/model/visual-candle.ts
+++ b/src/chart/model/visual-candle.ts
@@ -66,7 +66,7 @@ export default class VisualCandle extends VisualSeriesPoint {
 	 * @returns {Pixel} - The height of the body in pixels.
 	 */
 	bodyHeight(viewable: Viewable): Pixel {
-		return floorToDPR(Math.abs(viewable.toY(this.open) - viewable.toY(this.close)));
+		return floorToDPR(Math.max(Math.abs(viewable.toY(this.open) - viewable.toY(this.close)), 1));
 	}
 	/**
 	 * Calculates the height of a candle in pixels based on the high and low values of the candle and the viewable area.


### PR DESCRIPTION
Closes #168 
<img width="1021" alt="image" src="https://github.com/devexperts/dxcharts-lite/assets/44753430/90f8f7e1-3981-4a9a-b765-7dad2eecd392">
